### PR TITLE
Coerce strings to (vector character) before writing

### DIFF
--- a/README.org
+++ b/README.org
@@ -122,6 +122,18 @@ reader; the lisp function =pythonize= outputs strings which can be
 Note that python does not have all the numerical types which lisp has,
 for example rational numbers or complex integers.
 
+Because `python-eval` and `python-exec` evaluate strings as python
+expressions, strings passed to them are not escaped or converted as
+other types are. To pass a string to python as an argument, call `py4cl::pythonize`
+
+#+BEGIN_SRC lisp
+(let ((my-str "testing"))
+  (py4cl:python-eval "len(" (py4cl::pythonize my-str) ")" ))
+#+END_SRC
+
+#+RESULTS:
+: 7
+
 If python objects cannot be converted into a lisp value, then they are
 stored and a handle is returned to lisp. This handle can be used to
 manipulate the object, and when it is garbage collected the python

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -57,7 +57,8 @@ evals a list with a single element as a tuple
     (write-char #\) stream)))
 
 (defmethod pythonize ((obj string))
-  (write-to-string obj :escape t :readably t))
+  (write-to-string (coerce obj '(vector character))
+                   :escape t :readably t))
 
 (defmethod pythonize ((obj symbol))
   "Handle symbols. Need to handle NIL,

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -56,6 +56,16 @@
   (assert-equalp "say \"hello\" world"
       (py4cl:python-eval "'say \"hello\"' + ' world'")))
 
+(deftest pythonize-format-string (tests)
+  (print (py4cl::pythonize (format nil "foo")))
+  (assert-equalp "\"foo\""
+                 (py4cl::pythonize (format nil "foo"))))
+
+(deftest eval-format-string (pytests)
+  (assert-equalp "foo"
+                 (py4cl:python-eval
+                  (py4cl::pythonize (format nil "foo")))))
+
 ;; This tests whether outputs to stdout mess up the return stream
 (deftest eval-print (pytests)
   (unless (= 2 (first (py4cl:python-version-info)))


### PR DESCRIPTION
```
(py4cl::pythonize (format nil "foo"))
```
would result in
```
"#A((3) BASE-CHAR . \"foo\")"
```
(depending on reader settings). The argument is now always passed through `coerce` to type `(vector character)` to ensure consistent output.

Partly fixes issue #4 