### PR TITLE
Python methods and chain macro

### DIFF
--- a/README.org
+++ b/README.org
@@ -231,12 +231,20 @@ If the first argument is a list, then it is assumed to be a python
 function to be called; otherwise it is evaluated before converting to
 a python value. For example
 #+BEGIN_SRC lisp
-(py4cl:chain (range 3) stop)
+(py4cl:chain (slice 3) stop)
 #+END_SRC
+
+#+RESULTS:
+: 3
+
 is converted to the python:
 #+BEGIN_SRC python
-range(3).stop
+return slice(3).stop
 #+END_SRC
+
+#+RESULTS:
+: 3
+
 Symbols as first argument, or arguments to python methods, are
 evaluated, so the following works:
 #+BEGIN_SRC lisp

--- a/README.org
+++ b/README.org
@@ -179,6 +179,26 @@ Keywords are translated, with the symbol made lowercase:
 #+RESULTS:
 : -1
 
+** Calling python methods
+
+Python methods on objects can be called by using the =python-method= function. The first argument
+is the object (including strings, arrays, tuples); the second argument is either a string or a symbol
+specifying the method, followed by any arguments:
+#+BEGIN_SRC lisp
+(py4cl::python-method "hello {0}" 'format "world") ; => "hello world"
+#+END_SRC
+
+#+RESULTS:
+: hello world
+
+#+BEGIN_SRC lisp
+(py4cl::python-method '(1 2 3) '__len__) ; => 3
+#+END_SRC
+
+#+RESULTS:
+: 3
+
+
 ** Asynchronous python functions
 
 One of the advantages of using streams to communicate with a separate

--- a/README.org
+++ b/README.org
@@ -81,7 +81,8 @@ which is then plotted using the [[https://matplotlib.org/][matplotlib]] plotting
 
 For more direct access to the python subprocess, =python-eval=
 evaluates an expression, converting the result to a suitable lisp
-type.
+type. Note that there are nicer, more lispy wrappers around this function,
+described below, but they are mostly built on top of =python-eval=.
 
 #+BEGIN_SRC lisp
 (asdf:load-system "py4cl")
@@ -122,9 +123,9 @@ reader; the lisp function =pythonize= outputs strings which can be
 Note that python does not have all the numerical types which lisp has,
 for example rational numbers or complex integers.
 
-Because `python-eval` and `python-exec` evaluate strings as python
+Because =python-eval= and =python-exec= evaluate strings as python
 expressions, strings passed to them are not escaped or converted as
-other types are. To pass a string to python as an argument, call `py4cl::pythonize`
+other types are. To pass a string to python as an argument, call =py4cl::pythonize=
 
 #+BEGIN_SRC lisp
 (let ((my-str "testing"))
@@ -185,19 +186,106 @@ Python methods on objects can be called by using the =python-method= function. T
 is the object (including strings, arrays, tuples); the second argument is either a string or a symbol
 specifying the method, followed by any arguments:
 #+BEGIN_SRC lisp
-(py4cl::python-method "hello {0}" 'format "world") ; => "hello world"
+(py4cl:python-method "hello {0}" 'format "world") ; => "hello world"
 #+END_SRC
 
 #+RESULTS:
 : hello world
 
 #+BEGIN_SRC lisp
-(py4cl::python-method '(1 2 3) '__len__) ; => 3
+(py4cl:python-method '(1 2 3) '__len__) ; => 3
 #+END_SRC
 
 #+RESULTS:
 : 3
 
+** Chaining python methods
+
+In python it is quite common to apply a chain of method calls, data
+member access, and indexing operations to an object. To make this work
+smoothly in Lisp, there is the =chain= macro (Thanks to @kat-co and
+[[https://common-lisp.net/project/parenscript/reference.html][parenscript]] for the inspiration). This consists of a target object,
+followed by a chain of operations to apply.  For example
+#+BEGIN_SRC lisp
+(py4cl:chain "hello {0}" (format "world") (capitalize)) ; => "Hello world"
+#+END_SRC
+
+#+RESULTS:
+: Hello world
+
+which is converted to python 
+#+BEGIN_SRC python
+return "hello {0}".format("world").capitalize()
+#+END_SRC
+
+#+RESULTS:
+: Hello world
+
+The only things which are treated specially by this macro are lists
+and symbols at the top level. The first element of lists are treated as
+python method names, top-level symbols are treated as data
+members. Everything else is evaluated as lisp before being converted
+to a python value.
+
+If the first argument is a list, then it is assumed to be a python
+function to be called; otherwise it is evaluated before converting to
+a python value. For example
+#+BEGIN_SRC lisp
+(py4cl:chain (range 3) stop)
+#+END_SRC
+is converted to the python:
+#+BEGIN_SRC python
+range(3).stop
+#+END_SRC
+Symbols as first argument, or arguments to python methods, are
+evaluated, so the following works:
+#+BEGIN_SRC lisp
+(let ((format-str "hello {0}")
+      (argument "world"))
+ (py4cl:chain format-str (format argument))) ; => "hello world"
+#+END_SRC
+
+#+RESULTS:
+: hello world
+
+Arguments to methods are lisp, since only the top level forms in =chain= are treated specially:
+#+BEGIN_SRC lisp
+(py4cl:chain "result: {0}" (format (+ 1 2))) ; => "result: 3"
+#+END_SRC
+
+#+RESULTS:
+: result: 3
+
+Values at the top level (not symbols) are converted to python types
+and enclosed in =[]= brackets (usually =__getitem__= method in
+python). For example:
+#+BEGIN_SRC lisp
+(py4cl:chain "hello" 4) ; => "o"
+#+END_SRC
+is converted to the python
+#+BEGIN_SRC python
+return "hello"[4]
+#+END_SRC
+
+#+RESULTS:
+: o
+
+Slicing can be done by calling the python =slice= function:
+#+BEGIN_SRC lisp
+(py4cl:chain "hello" (__getitem__ (py4cl:python-call "slice" 2 4)))  ; => "ll"
+#+END_SRC
+
+#+RESULTS:
+: ll
+
+which could be imported as a lisp function (see below):
+#+BEGIN_SRC lisp
+(py4cl:import-function "slice")
+(py4cl:chain "hello" (__getitem__ (slice 2 4))) ; => "ll"
+#+END_SRC
+
+#+RESULTS:
+: ll
 
 ** Asynchronous python functions
 

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -162,6 +162,26 @@ Returns a lambda which when called returns the result."
             ;; If no handle then already have the value
             value)))))
 
+(defun python-method (obj method-name &rest args)
+  "Call a given method on an object OBJ. METHOD-NAME can be a
+symbol (converted to lower case) or a string. 
+
+Examples:
+ 
+  (python-method \"hello {0}\" 'format \"world\") 
+  ; => \"hello world\"
+
+  (python-method '(1 2 3) '__len__)
+  ; => 3
+"
+  (python-start-if-not-alive)
+  (py4cl:python-eval
+   (py4cl::pythonize obj)
+   (format nil ".~(~a~)" method-name)
+   (if args 
+       (py4cl::pythonize args)
+       "()")))
+
 (defmacro import-function (fun-name &key docstring
                                       (as (read-from-string fun-name)))
   "Define a function which calls python

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -13,6 +13,7 @@
    #:python-exec
    #:python-call
    #:python-call-async
+   #:python-method
    #:import-function
    #:import-module
    #:export-function

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -14,6 +14,7 @@
    #:python-call
    #:python-call-async
    #:python-method
+   #:chain
    #:import-function
    #:import-module
    #:export-function

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -374,3 +374,19 @@ a = Test()")
   (assert-equalp "hello world"
       (py4cl:python-method "hello {0}" 'format "world")))
 
+(deftest chain (pytests)
+  (assert-equalp "Hello world"
+      (py4cl:chain "hello {0}" (format "world") (capitalize)))
+  (assert-equalp "hello world"
+      (let ((format-str "hello {0}")
+            (argument "world"))
+        (py4cl:chain format-str (format argument))))
+  (assert-equalp "result: 3"
+      (py4cl:chain "result: {0}" (format (+ 1 2))))
+  (assert-equalp 3
+      (py4cl:chain (range 3) stop))
+  (assert-equalp "o"
+      (py4cl:chain "hello" 4)))
+
+
+    

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -384,7 +384,7 @@ a = Test()")
   (assert-equalp "result: 3"
       (py4cl:chain "result: {0}" (format (+ 1 2))))
   (assert-equalp 3
-      (py4cl:chain (range 3) stop))
+      (py4cl:chain (slice 3) stop))
   (assert-equalp "o"
       (py4cl:chain "hello" 4)))
 

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -368,3 +368,9 @@ a = Test()")
   
   (assert-false (py4cl:python-alive-p)))
 
+(deftest python-method (pytests)
+  (assert-equalp 3
+      (py4cl:python-method '(1 2 3) '__len__))
+  (assert-equalp "hello world"
+      (py4cl:python-method "hello {0}" 'format "world")))
+


### PR DESCRIPTION
Two ways to access python object methods

- A function `python-method` which takes an object, a method names, and arguments.
- A macro `chain` which allows multiple methods to be called in turn. 

A simple example is the python `"hello {0}".format("world")` which can be written as:
```
(py4cl:python-method "hello {0}" 'format "world")
```
or
```
(py4cl:chain "hello {0}" (format "world"))
```
See README and tests for more examples

Fixes #4