### PR TITLE
Add [] method to chain macro

### DIFF
--- a/README.org
+++ b/README.org
@@ -264,13 +264,24 @@ Arguments to methods are lisp, since only the top level forms in =chain= are tre
 #+RESULTS:
 : result: 3
 
-Values at the top level (not symbols) are converted to python types
-and enclosed in =[]= brackets (usually =__getitem__= method in
-python). For example:
+Indexing with =[]= brackets is commonly used in python, which calls the =__getitem__= method.
+This method can be called like any other method
 #+BEGIN_SRC lisp
-(py4cl:chain "hello" 4) ; => "o"
+(py4cl:chain "hello" (__getitem__ 4)) ; => "o"
 #+END_SRC
-is converted to the python
+
+#+RESULTS:
+: o
+
+but since this is a common method an alias =[]= is supported:
+#+BEGIN_SRC lisp
+(py4cl:chain "hello" ([] 4)) ; => "o"
+#+END_SRC
+
+#+RESULTS:
+: o
+
+which is converted to the python
 #+BEGIN_SRC python
 return "hello"[4]
 #+END_SRC
@@ -278,9 +289,18 @@ return "hello"[4]
 #+RESULTS:
 : o
 
+For simple cases where the index is a value like a number or string
+(not a symbol or a list), the brackets can be omitted:
+#+BEGIN_SRC lisp
+(py4cl:chain "hello" 4) ; => "o"
+#+END_SRC
+
+#+RESULTS:
+: o
+
 Slicing can be done by calling the python =slice= function:
 #+BEGIN_SRC lisp
-(py4cl:chain "hello" (__getitem__ (py4cl:python-call "slice" 2 4)))  ; => "ll"
+(py4cl:chain "hello" ([] (py4cl:python-call "slice" 2 4)))  ; => "ll"
 #+END_SRC
 
 #+RESULTS:
@@ -289,11 +309,19 @@ Slicing can be done by calling the python =slice= function:
 which could be imported as a lisp function (see below):
 #+BEGIN_SRC lisp
 (py4cl:import-function "slice")
-(py4cl:chain "hello" (__getitem__ (slice 2 4))) ; => "ll"
+(py4cl:chain "hello" ([] (slice 2 4))) ; => "ll"
 #+END_SRC
 
 #+RESULTS:
 : ll
+
+This of course also works with multidimensional arrays:
+#+BEGIN_SRC lisp
+(py4cl:chain #2A((1 2 3) (4 5 6))  ([] 1 (slice 0 2)))  ;=> #(4 5)
+#+END_SRC
+
+#+RESULTS:
+| 4 | 5 |
 
 ** Asynchronous python functions
 

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -222,10 +222,20 @@ Examples:
     ,@(loop for link in chain
          appending
            (cond
-             ((consp link) (list (format nil ".~(~a~)" (first link))
+             ((consp link)
+              ;; A list. Usually a method to call, but [] indicates __getitem__
+              (if (string= (first link) "[]")
+                  ;; Calling the __getitem__ method
+                  (list "[" (list 'py4cl::pythonize  ; So that strings are escaped
+                                  (if (cddr link)
+                                      (append '(list) (rest link)) ; More than one -> wrap in list/tuple
+                                      (cadr link))) ; Only one -> no tuple
+                        "]")
+                  ;; Calling a method
+                  (list (format nil ".~(~a~)" (first link))
                                  (if (rest link)
-                                     `(list ,@(rest link)) 
-                                     "()")))
+                                     (append '(list) (rest link))
+                                     "()"))))
              ((symbolp link) (list (format nil ".~(~a~)" link)))
              (t (list "[" (list 'py4cl::pythonize link) "]"))))))
 

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -374,6 +374,10 @@ a = Test()")
   (assert-equalp "hello world"
       (py4cl:python-method "hello {0}" 'format "world")))
 
+
+;; Shorter more convenient slicing
+(py4cl:import-function "slice")
+
 (deftest chain (pytests)
   (assert-equalp "Hello world"
       (py4cl:chain "hello {0}" (format "world") (capitalize)))
@@ -385,8 +389,26 @@ a = Test()")
       (py4cl:chain "result: {0}" (format (+ 1 2))))
   (assert-equalp 3
       (py4cl:chain (slice 3) stop))
+
+  ;; Anything not a list or a symbol is put between [] brackets (__getitem__)
   (assert-equalp "o"
-      (py4cl:chain "hello" 4)))
+      (py4cl:chain "hello" 4))
+
+  ;; [] operator for indexing and slicing (alias for __getitem__)
+  
+  (assert-equalp "l"
+      (py4cl:chain "hello" ([] 3)))
+  (assert-equalp 3
+      (py4cl:chain #2A((1 2) (3 4))  ([] 1 0)))
+  (assert-equalp #(4 5)
+      (py4cl:chain #2A((1 2 3) (4 5 6))  ([] 1 (slice 0 2))))
+
+  (let ((dict (py4cl:python-eval "{\"hello\":\"world\", \"ping\":\"pong\"}")))
+    (assert-equalp "world"
+        (py4cl:chain dict "hello"))
+    (assert-equalp "pong"
+        (py4cl:chain dict ([] "ping")))))
+  
 
 
     


### PR DESCRIPTION
Calling `__getitem__` is a common thing to want to do, and is a bit verbose. Some python and lisp code examples:
```
"hello"[x]  -> (chain "hello" (__getitem__ x))
```
and for arrays:
```
array[x,y]  -> (chain array (__getitem__ (list x y)))
```

This adds `[]` as an alias for `__getitem__`, and handles one or multiple arguments:
```
"hello"[x]  -> (chain "hello" ([] x))
```
and
```
array[x,y]  -> (chain array ([] x y))
```