### PR TITLE
Use ASDF:system-source-directory

### DIFF
--- a/py4cl.asd
+++ b/py4cl.asd
@@ -21,7 +21,7 @@
 ;; suggested here https://xach.livejournal.com/294639.html
 (defpackage #:py4cl/config (:export #:*base-directory*))
 (defparameter py4cl/config:*base-directory* 
-  (make-pathname :name nil :type nil :defaults *load-truename*))
+  (asdf:system-source-directory "py4cl"))
 
 (asdf:defsystem "py4cl/tests"
   :serial t


### PR DESCRIPTION
Suggested by @rpgoldman as a replacement for `*load-truename*` to account for differences between implementations.

Fixes issue #14