### PR TITLE
Enable handling of unicode type strings

### DIFF
--- a/py4cl.py
+++ b/py4cl.py
@@ -154,6 +154,7 @@ lispifiers = {
     # Note: With dict -> hash table, use :test 'equal so that string keys work as expected
     dict       : lambda x: "#.(let ((table (make-hash-table :test 'equal))) " + " ".join("(setf (gethash {} table) {})".format(lispify(key), lispify(value)) for key, value in x.items()) + " table)",
     str        : lambda x: "\"" + x.replace("\\", "\\\\").replace('"', '\\"')  + "\"",
+    type(u'unicode') : lambda x: "\"" + x.replace("\\", "\\\\").replace('"', '\\"')  + "\"",  # Unicode in python 2
     Symbol     : str,
     UnknownLispObject : lambda x: "#.(py4cl::lisp-object {})".format(x.handle),
 }

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -593,3 +593,14 @@ class testclass:
   (assert-equalp 6
       (py4cl:remote-objects*
         (py4cl:python-call (lambda (x y) (* x y)) 2 3))))
+
+
+(deftest unicode-string-type (pytests)
+  ;; Python 2 and python 3 handle unicode differently
+  ;; This just catches the use of unicode type strings in python2
+  ;; not the use of unicode characters
+  (assert-equal "test unicode"
+                (py4cl:python-eval "u'test unicode'"))
+  (assert-equal 3
+                (gethash "pizza"
+                         (py4cl:python-eval "{u'pizza': 3}"))))


### PR DESCRIPTION
In python 2 unicode strings have type 'unicode', whereas in python3 all strings are of type 'str'

Note: Actual unicode characters still can't be used with python2.