### PR TITLE
Use exec when launching Python

### DIFF
--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -24,6 +24,7 @@ By default this is is set to *PYTHON-COMMAND*
   (setf *python*
         (uiop:launch-program
          (concatenate 'string
+                      #+os-unix "exec "
                       command  ; Run python executable
                       " "
                       ;; Path *base-pathname* is defined in py4cl.asd


### PR DESCRIPTION
Trivial improvement for when one looks at the process tree, feel free to reject.

Thank you for your work!