### PR TITLE
py4cl2 backport with minimal changes

### DIFF
--- a/py4cl.asd
+++ b/py4cl.asd
@@ -5,7 +5,7 @@
   :description "Call Python libraries from Common Lisp"
   :author "Ben Dudson <benjamin.dudson@york.ac.uk>"
   :license "MIT"
-  :depends-on ("trivial-garbage")
+  :depends-on ("trivial-garbage" "uiop" "bordeaux-threads")
   :pathname #P"src/"
   :serial t
   :components ((:file "package")

--- a/py4cl.asd
+++ b/py4cl.asd
@@ -5,7 +5,7 @@
   :description "Call Python libraries from Common Lisp"
   :author "Ben Dudson <benjamin.dudson@york.ac.uk>"
   :license "MIT"
-  :depends-on ("trivial-garbage" "uiop" "bordeaux-threads" "cl-json" "numpy-file-format")
+  :depends-on ("trivial-garbage" "uiop" "cl-json" "numpy-file-format")
   :pathname #P"src/"
   :serial t
   :components ((:file "package")
@@ -32,7 +32,8 @@
   :license "MIT"
   :depends-on ("py4cl"
                "clunit"
-               "trivial-garbage")
+               "trivial-garbage"
+               "bordeaux-threads")
   :pathname #P"tests/"
   :components ((:file "tests"))
   :perform (test-op (o c) (symbol-call :py4cl/tests :run)))

--- a/py4cl.asd
+++ b/py4cl.asd
@@ -5,16 +5,18 @@
   :description "Call Python libraries from Common Lisp"
   :author "Ben Dudson <benjamin.dudson@york.ac.uk>"
   :license "MIT"
-  :depends-on ("trivial-garbage" "uiop" "bordeaux-threads")
+  :depends-on ("trivial-garbage" "uiop" "bordeaux-threads" "cl-json" "numpy-file-format")
   :pathname #P"src/"
   :serial t
   :components ((:file "package")
+               (:file "config")
                (:file "reader")
                (:file "writer")
                (:file "python-process")
                (:file "lisp-classes")
                (:file "callpython")
-               (:file "import-export"))
+               (:file "import-export")
+               (:file "do-after-load"))
   :in-order-to ((test-op (test-op "py4cl/tests"))))
 
 ;; This is to store the path to the source code

--- a/py4cl.py
+++ b/py4cl.py
@@ -236,6 +236,12 @@ def lispify(obj):
         # Another unknown type. Return a handle to a python object
         return lispify_handle(obj)
 
+def generator(function, stop_value):
+    temp = None
+    while True:
+        temp = function()
+        if temp == stop_value: break
+        yield temp
 
 ##################################################################
 
@@ -414,6 +420,7 @@ eval_globals["_py4cl_LispCallbackObject"] = LispCallbackObject
 eval_globals["_py4cl_Symbol"] = Symbol
 eval_globals["_py4cl_UnknownLispObject"] = UnknownLispObject
 eval_globals["_py4cl_objects"] = python_objects
+eval_globals["_py4cl_generator"] = generator
 # These store the environment used when eval'ing strings from Lisp
 # - particularly for numpy pickling
 eval_globals["_py4cl_config"] = config

--- a/py4cl.py
+++ b/py4cl.py
@@ -52,8 +52,11 @@ class LispCallbackObject (object):
         """
         Delete this object, sending a message to Lisp
         """
-        return_stream.write("d")
-        send_value(self.handle)
+        try:
+            return_stream.write("d")
+            send_value(self.handle)
+        finally:
+            pass
 
     def __call__(self, *args, **kwargs):
         """
@@ -97,8 +100,11 @@ class UnknownLispObject (object):
         """
         Delete this object, sending a message to Lisp
         """
-        return_stream.write('d')
-        send_value(self.handle)
+        try:
+            return_stream.write('d')
+            send_value(self.handle)
+        finally:
+            pass
 
     def __str__(self):
         return "UnknownLispObject(\""+self.lisptype+"\", "+str(self.handle)+")"

--- a/py4cl.py
+++ b/py4cl.py
@@ -21,10 +21,10 @@ except:
 # Direct stdout to a StringIO buffer,
 # to prevent commands from printing to the output stream
 
+write_stream = sys.stdout
+redirect_stream = StringIO()
 
-return_stream = sys.stdout
-output_stream = sys.stderr
-sys.stdout = sys.stderr
+sys.stdout = redirect_stream
 
 config = {}
 def load_config():
@@ -67,10 +67,11 @@ class LispCallbackObject (object):
         Delete this object, sending a message to Lisp
         """
         try:
-            return_stream.write("d")
+            sys.stdout = write_stream
+            write_stream.write("d")
             send_value(self.handle)
-        except:
-            pass
+        finally:
+            sys.stdout = redirect_stream
 
     def __call__(self, *args, **kwargs):
         """
@@ -88,11 +89,14 @@ class LispCallbackObject (object):
 
         old_return_values = return_values # Save to restore after
         try:
-            return_values = 0
-            return_stream.write('c')
+            return_values = 0 # Need to send the values
+            sys.stdout = write_stream
+            write_stream.write("c")
             send_value((self.handle, allargs))
-        finally: 
+        finally:
             return_values = old_return_values
+            sys.stdout = redirect_stream
+
         # Wait for a value to be returned.
         # Note that the lisp function may call python before returning
         return message_dispatch_loop()
@@ -115,18 +119,24 @@ class UnknownLispObject (object):
         Delete this object, sending a message to Lisp
         """
         try:
-            return_stream.write('d')
+            sys.stdout = write_stream
+            write_stream.write("d")
             send_value(self.handle)
-        except:
-            pass
+        finally:
+            sys.stdout = redirect_stream
 
     def __str__(self):
         return "UnknownLispObject(\""+self.lisptype+"\", "+str(self.handle)+")"
 
     def __getattr__(self, attr):
         # Check if there is a slot with this name
-        return_stream.write('s')
-        send_value((self.handle, attr))
+        try:
+            sys.stdout = write_stream
+            write_stream.write("s") # Slot access
+            send_value((self.handle, attr))
+        finally:
+            sys.stdout = redirect_stream
+
         # Wait for the result
         return message_dispatch_loop()
         
@@ -265,31 +275,56 @@ def send_value(value):
     """
     Send a value to stdout as a string, with length of string first
     """
-    
     try:
         value_str = lispify(value)
     except Exception as e:
         # At this point the message type has been sent,
         # so we can't change to throw an exception/signal condition
         value_str = "Lispify error: " + str(e)
-    print(len(value_str), file = return_stream)
-    return_stream.write(value_str)
-    return_stream.flush()
-     
+    print(len(value_str))
+    write_stream.write(value_str)
+    write_stream.flush()
 
+def return_stdout():
+    """
+    Return the contents of redirect_stream, to be printed to stdout
+    """
+    global redirect_stream
+    global return_values
+    
+    contents = redirect_stream.getvalue()
+    if not contents:
+        return  # Nothing to send
+
+    redirect_stream = StringIO() # New stream, delete old one
+
+    old_return_values = return_values # Save to restore after
+    try:
+        return_values = 0 # Need to return the string, not a handle
+        sys.stdout = write_stream
+        write_stream.write("p")
+        send_value(contents)
+    finally:
+        return_values = old_return_values
+        sys.stdout = redirect_stream
+    
 def return_error(err):
     """
     Send an error message
     """
     global return_values
 
+    return_stdout() # Send stdout if any
+    
     old_return_values = return_values # Save to restore after
     try:
         return_values = 0 # Need to return the error, not a handle
-        return_stream.write('e')
+        sys.stdout = write_stream
+        write_stream.write("e")
         send_value(str(err))
     finally:
         return_values = old_return_values
+        sys.stdout = redirect_stream
 
 def return_value(value):
     """
@@ -297,9 +332,16 @@ def return_value(value):
     """
     if isinstance(value, Exception):
         return return_error(value)
+
+    return_stdout() # Send stdout if any
+    
     # Mark response as a returned value
-    return_stream.write('r')
-    send_value(value)
+    try:
+        sys.stdout = write_stream
+        write_stream.write("r")
+        send_value(value)
+    finally:
+        sys.stdout = redirect_stream
         
 def message_dispatch_loop():
     """

--- a/py4cl.py
+++ b/py4cl.py
@@ -237,7 +237,7 @@ def send_value(value):
         # At this point the message type has been sent,
         # so we can't change to throw an exception/signal condition
         value_str = "Lispify error: " + str(e)
-    print(len(value_str), file = return_stream, flush=True)
+    print(len(value_str), file = return_stream)
     return_stream.write(value_str)
     return_stream.flush()
      

--- a/py4cl.py
+++ b/py4cl.py
@@ -370,6 +370,8 @@ def message_dispatch_loop():
             else:
                 return_error("Unknown message type '{0}'".format(cmd_type))
 
+        except KeyboardInterrupt as e:
+            return_value(None)
         except Exception as e:
             return_error(e)
 

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -170,6 +170,9 @@ Examples:
        (py4cl::pythonize args)
        "()")))
 
+(defun python-generator (function stop-value)
+  (python-call "_py4cl_generator" function stop-value))
+
 (defun function-args (args)
   "Internal function, intended to be called by the CHAIN macro.
 Converts function arguments to a list of strings and (pythonize )

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -1,0 +1,65 @@
+(in-package :py4cl)
+
+;; Particularly for numpy
+
+(defvar *config* () "Used for storing configuration at a centralized location.")
+;; Refer initialize function to note which variables are included under *config*
+
+(defun take-input (prompt default)
+  (format t prompt)
+  (force-output)
+  (let ((input (read-line)))
+    (if (string= "" input) default input)))
+
+(defun initialize ()
+  "Intended to be called first upon installation. Sets up default python command,
+and numpy pickle file and lower bounds."
+  (let ((pycmd (take-input "Provide the python binary to use (default python): "
+                           "python"))
+        (numpy-pickle-location
+         (take-input "~%PY4CL uses pickled files to transfer large arrays between lisp
+ and python efficiently. These are expected to have sizes exceeding 100MB 
+ (this depends on the value of *NUMPY-PICKLE-LOWER-BOUND*). Therefore, choose an 
+ appropriate location (*NUMPY-PICKLE-LOCATION*) for storing these arrays on disk.
+
+Enter full file path for storage (default /tmp/_numpy_pickle.npy): "
+                     "/tmp/_numpy_pickle.npy"))
+        (numpy-pickle-lower-bound
+         (parse-integer
+          (take-input "Enter lower bound for using pickling (default 100000): "
+                      "100000"))))
+    (setq  *config* ;; case conversion to and from symbols is handled by cl-json
+           `((pycmd . ,pycmd)
+             (numpy-pickle-location . ,numpy-pickle-location)
+             (numpy-pickle-lower-bound . ,numpy-pickle-lower-bound)))
+    ;; to avoid development overhead, we will not bring these variables "out"
+    (save-config)))
+
+(defun save-config ()
+  (let ((config-path (concatenate 'string
+                                  (directory-namestring py4cl/config:*base-directory*)
+                                  ".config")))
+    
+    (with-open-file (f config-path :direction :output :if-exists :supersede
+                       :if-does-not-exist :create)
+      (cl-json:encode-json-alist *config* f))
+    (format t "Configuration is saved to ~D.~%" config-path)))
+
+(defun load-config ()
+  (let ((config-path (concatenate 'string
+                                  (directory-namestring py4cl/config:*base-directory*)
+                                  ".config"))
+        (cl-json:*json-symbols-package* *package*))
+    (setq *config* (with-open-file (f config-path)
+                     (cl-json:decode-json f)))))
+
+(defun config-var (var) (cdr (assoc var *config*)))
+(defun (setf config-var) (new-value var)
+  (setf (cdr (assoc var *config*)) new-value)
+  ;; say, the user wants the python process to be project local
+  (unless (eq var 'pycmd) (save-config))
+  (when (python-alive-p) (pycall "_py4cl_load_config")))
+
+(defun py-cd (path)
+  (pyexec "import os")
+  (pycall "os.chdir" path))

--- a/src/do-after-load.lisp
+++ b/src/do-after-load.lisp
@@ -1,0 +1,10 @@
+;;; probably, ASDF should have a feature for doing this
+;;; this file should be called after loading all the other files
+
+(in-package :py4cl)
+(let ((config-path (concatenate 'string
+                                (directory-namestring py4cl/config:*base-directory*)
+                                ".config"))
+      (cl-json:*json-symbols-package* *package*))
+  (when (uiop:file-exists-p config-path)
+    (load-config)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -26,4 +26,14 @@
    #:import-module
    #:export-function)
   (:export ; lisp-classes
-   #:python-getattr))
+   #:python-getattr)
+  (:export ; config 
+   #:*config*
+   #:initialize
+   #:save-config
+   #:load-config
+   #:config-var
+   #:pycmd
+   #:numpy-pickle-location
+   #:numpy-pickle-lower-bound
+   #:py-cd))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -17,6 +17,7 @@
    #:python-call
    #:python-call-async
    #:python-method
+   #:python-generator
    #:chain
    #:python-setf
    #:remote-objects

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -8,7 +8,8 @@
    #:python-stop
    #:python-alive-p
    #:python-start-if-not-alive
-   #:python-version-info)
+   #:python-version-info
+   #:python-interrupt)
   (:export ; callpython
    #:python-error
    #:python-eval

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -77,6 +77,15 @@ If still not alive, raises a condition."
   ;; Clear lisp objects
   (clear-lisp-objects))
 
+(defun python-interrupt (&optional (process-info *python*))
+  (when (python-alive-p process-info)
+    (uiop:run-program
+     (concatenate 'string "/bin/kill -SIGINT -"
+		  (write-to-string (uiop:process-info-pid process-info)))
+     :force-shell t)
+    ;; something to do with running in separate threads! "deftest interrupt"
+    (unless *py4cl-tests* (dispatch-messages process-info))))
+
 (defun python-version-info ()
   "Return a list, using the result of python's sys.version_info."
   (python-start-if-not-alive)

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -2,7 +2,7 @@
 
 (in-package :py4cl)
 
-(defvar *python-command* "/home/shubhamkar/miniconda3/bin/python"
+(defvar *python-command* "python"
   "String, the Python executable to launch
 e.g. \"python\" or \"python3\"")
 

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -14,9 +14,6 @@ e.g. \"python\" or \"python3\"")
 is used to prevent garbage collection from deleting objects in the wrong
 python session")
 
-(defvar *py4cl-tests* nil
-  "Set to true, during testing, for obtaining output to a string.")
-
 (defun python-start (&optional (command *python-command*))
   "Start a new python subprocess
 This sets the global variable *python* to the process handle,
@@ -27,19 +24,13 @@ By default this is is set to *PYTHON-COMMAND*
   (setf *python*
         (uiop:launch-program
          (concatenate 'string
+                      "exec "
                       command  ; Run python executable
-                      " -u "
+                      " "
                       ;; Path *base-pathname* is defined in py4cl.asd
                       ;; Calculate full path to python script
                       (namestring (merge-pathnames #p"py4cl.py" py4cl/config:*base-directory*)))
-         :input :stream :output :stream :error-output :stream))
-  (unless *py4cl-tests*
-    (bt:make-thread (lambda ()
-                      (when *python*
-                        (let ((py-out (uiop:process-info-error-output *python*)))
-                          (loop while (and *python* (python-alive-p *python*))
-                             for char = (read-char py-out nil)
-                             do (when char (write-char char))))))))
+         :input :stream :output :stream))
   (incf *current-python-process-id*))
 
 (defun python-alive-p (&optional (process *python*))
@@ -69,6 +60,8 @@ If still not alive, raises a condition."
   ;; Could give it a few seconds to close nicely
   (let ((stream (uiop:process-info-input process)))
     (write-char #\q stream))
+  ;; Close input, output streams
+  (uiop:close-streams process)
   ;; Terminate
   (uiop:terminate-process process)
   ;; Mark as not alive
@@ -77,6 +70,8 @@ If still not alive, raises a condition."
   ;; Clear lisp objects
   (clear-lisp-objects))
 
+(defvar *py4cl-tests* nil "Set nil for something like py4cl/tests::interrupt test,
+for unknown reasons.")
 (defun python-interrupt (&optional (process-info *python*))
   (when (python-alive-p process-info)
     (uiop:run-program

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -27,7 +27,6 @@ By default this is is set to *PYTHON-COMMAND*
   (setf *python*
         (uiop:launch-program
          (concatenate 'string
-                      #+os-unix "exec "
                       command  ; Run python executable
                       " -u "
                       ;; Path *base-pathname* is defined in py4cl.asd

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -32,6 +32,16 @@ try:
 except:
   pass")))))
 
+(defun delete-numpy-pickle-arrays ()
+  "Delete pickled arrays, to free space."
+  (iter (while (> *numpy-pickle-index* 0))
+        (for filename =
+             (concatenate 'string
+                          (config-var 'numpy-pickle-location)
+                          "." (write-to-string *numpy-pickle-index*)))
+        (uiop:delete-file-if-exists filename)
+        (decf *numpy-pickle-index*)))
+
 (defun make-python-object-finalize (&key (type "") handle)
     "Make a PYTHON-OBJECT struct with a finalizer.
 This deletes the object from the dict store in python.

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -65,7 +65,23 @@ which is interpreted correctly by python (3.7.2)."
                (write-to-string (imagpart obj))
                "j)"))
 
+(defvar *numpy-pickle-index* 0
+  "Used for transferring multiple numpy-pickled arrays in one pyeval/exec/etc")
+;; this is incremented by pythonize and reset to 0 at the beginning of
+;; every pyeval*/pycall from delete-numpy-pickle-arrays in reader.lisp
 (defmethod pythonize ((obj array))
+  (when (and (config-var 'numpy-pickle-lower-bound)
+             (config-var 'numpy-pickle-location)
+             (> (array-total-size obj)
+                (config-var 'numpy-pickle-lower-bound)))
+    (let ((filename (concatenate 'string
+				 (config-var 'numpy-pickle-location)
+				 "." (write-to-string (incf *numpy-pickle-index*)))))
+      (numpy-file-format:store-array obj filename)
+      (return-from pythonize
+	(concatenate 'string "_py4cl_load_pickled_ndarray_and_delete('"
+		     filename"')"))))
+  
   ;; Handle case of empty array
   (if (= (array-total-size obj) 0)
       (return-from pythonize "[]"))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -19,6 +19,13 @@
   "Run all the tests for py4cl."
   (run-suite 'tests :use-debugger interactive?))
 
+(defun read-py4cl-output ()
+  (let ((py-out (uiop:process-info-error-output py4cl::*python*)))
+    (with-output-to-string (str)
+      (loop while (listen py-out)
+         for char = (read-char py-out nil)
+         do (write-char char str)))))
+
 ;; Start and stop Python, check that python-alive-p responds
 (deftest start-stop (tests)
   (assert-false (py4cl:python-alive-p))
@@ -69,21 +76,25 @@
 (deftest eval-print (pytests)
   (unless (= 2 (first (py4cl:python-version-info)))
     ;; Should return the result of print, not the string printed
-    (assert-equalp nil
-        (py4cl:python-eval "print(\"hello\")")
+    (let ((py4cl::*py4cl-tests* t))
+      (py4cl:python-stop)
+      (assert-equalp nil
+          (py4cl:python-eval "print(\"hello\")")
         "This fails with python 2")
 
-    ;; Should print the output to stdout
-    (assert-equalp "hello world
-"
-                   (with-output-to-string (*standard-output*)
-                     (py4cl:chain (print "hello world"))))
+      (py4cl:python-stop)
 
-    ;; Check that the output is cleared, by printing a shorter string
-    (assert-equalp "testing
+      ;; Should print the output to stdout
+      (assert-equalp "hello world
 "
-                   (with-output-to-string (*standard-output*)
-                     (py4cl:chain (print "testing"))))))
+          (progn (py4cl:chain (print "hello world"))
+                 (read-py4cl-output)))
+
+      ;; Check that the output is cleared, by printing a shorter string
+      (assert-equalp "testing
+"
+          (progn (py4cl:chain (print "testing"))
+                 (read-py4cl-output))))))
 
 (deftest eval-params (pytests)
   ;; Values are converted into python values

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -1,4 +1,4 @@
-
+(py4cl:import-module "math" :reload t)
 (defpackage #:py4cl/tests
   (:use #:cl #:clunit)
   (:export #:run))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -616,6 +616,29 @@ class testclass:
                 (gethash "pizza"
                          (py4cl:python-eval "{u'pizza': 3}"))))
 
+;; ============================== PICKLE =======================================
+
+(deftest transfer-multiple-arrays (pytests)
+  (when (and (py4cl:config-var 'py4cl:numpy-pickle-location)
+             (py4cl:config-var 'py4cl:numpy-pickle-lower-bound))
+    (let ((dimensions `((,(py4cl:config-var 'py4cl:numpy-pickle-lower-bound))
+                        (,(* 5 (py4cl:config-var 'py4cl:numpy-pickle-lower-bound))))))
+      (assert-equalp dimensions
+                     (mapcar #'array-dimensions 
+                             (py4cl:python-eval
+                              (list (make-array (first dimensions) :element-type 'single-float)
+                                    (make-array (second dimensions) :element-type 'single-float))))
+                     "No bound or location for pickling."))))
+
+(deftest transfer-without-pickle (pytests)
+  (unless (and (py4cl:config-var 'py4cl:numpy-pickle-location)
+               (py4cl:config-var 'py4cl:numpy-pickle-lower-bound))
+    (assert-equalp '(100000)
+                   (array-dimensions
+                    (py4cl:python-eval (make-array 100000 :element-type 'single-float)))
+      "Pickle bound and location is present.")))
+
+
 ;; ==================== PROCESS-INTERRUPT ======================================
 
 ;; Unable to test on CCL:

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -307,6 +307,25 @@
     (assert-equalp 42
                    (gethash "test" table))))
 
+;; Generators
+(deftest generator (pytests)
+  (assert-equalp (ecase (car (py4cl:python-version-info))
+                   (3 "<class 'generator'>")
+                   (2 "<type 'generator'>"))
+      (slot-value (py4cl:python-generator #'identity 3) 'type))
+  (py4cl:python-exec "
+def foo(gen):
+  return list(gen)")
+  (assert-equalp #(1 2 3 4)
+      (let ((gen (py4cl:python-generator (let ((x 0)) (lambda () (incf x)))
+                                         5)))
+        (py4cl:python-call "foo" gen)))
+  (assert-equalp #(#\h #\e #\l #\l #\o) 
+      (let ((gen (py4cl:python-generator (let ((str (make-string-input-stream "hello")))
+                                           (lambda () (read-char str nil)))
+                                         nil)))
+        (py4cl:python-call "foo" gen))))
+
 ;; Asyncronous functions
 (deftest call-function-async (pytests)
   (let ((thunk (py4cl:python-call-async "str" 42)))


### PR DESCRIPTION
Amongst the changes I'm aware of, one remains is that of numpy arrays using numpy-file-format, and generators. I can make it later this week.

I think the following changes merit a new major version, since it can literally break user code:
- changes to import-module and import-function, to defpymodule and defpyfun, importing arguments, lispifying names
- changes to chain, chain*
- changing remote-object to with-remote-object, if semantics deem appropriate

IMO, this PR is much cleaner. That went all over the place. :)

Also, [dzecniv suggested an idea of gentle deprecation for change of names](https://www.reddit.com/r/lisp/comments/cyf6k9/improving_upon_py4cl/eyvsse6?utm_source=share&utm_medium=web2x)