### PR TITLE
Fix: transfer multiple pickled array; test was passing incorrectly

### DIFF
--- a/py4cl.py
+++ b/py4cl.py
@@ -179,23 +179,35 @@ numeric_base_classes = (numbers.Number,)
 try:
     # Use NumPy for multi-dimensional arrays
     import numpy
-
-    def load_pickled_ndarray_and_delete(filename):
+    NUMPY_PICKLE_INDEX = 0 # optional increment in lispify_ndarray and reset to 0
+    def load_pickled_ndarray(filename):
         arr = numpy.load(filename, allow_pickle = True)
-        os.remove(filename)
         return arr
+
+    def delete_numpy_pickle_arrays():
+        global NUMPY_PICKLE_INDEX
+        while NUMPY_PICKLE_INDEX > 0:
+            NUMPY_PICKLE_INDEX -= 1
+            numpy_pickle_location = config["numpyPickleLocation"] \
+                                    + ".from." + str(NUMPY_PICKLE_INDEX)
+            if os.path.exists(numpy_pickle_location):
+                os.remove(numpy_pickle_location)
 
     def lispify_ndarray(obj):
         """Convert a NumPy array to a string which can be read by lisp
         Example:
         array([[1, 2],     => '#2A((1 2) (3 4))'
-              [3, 4]])
+               [3, 4]])
         """
+        global NUMPY_PICKLE_INDEX
         if "numpyPickleLowerBound" in config and \
            "numpyPickleLocation" in config and \
            obj.size > config["numpyPickleLowerBound"]:
-            numpy_pickle_location = config["numpyPickleLocation"]
-            numpy.save(numpy_pickle_location, obj, allow_pickle = True)
+            numpy_pickle_location = config["numpyPickleLocation"] \
+                + ".from." + str(NUMPY_PICKLE_INDEX)
+            NUMPY_PICKLE_INDEX += 1
+            with open(numpy_pickle_location, "wb") as f:
+                numpy.save(f, obj, allow_pickle = True)
             return ('#.(numpy-file-format:load-array "'
                     + numpy_pickle_location + '")')
         if obj.ndim == 0:
@@ -363,6 +375,7 @@ def message_dispatch_loop():
         try:
             # Read command type
             cmd_type = sys.stdin.read(1)
+            delete_numpy_pickle_arrays()
             
             if cmd_type == "e":  # Evaluate an expression
                 result = eval(recv_string(), eval_globals, eval_locals)
@@ -470,8 +483,8 @@ eval_globals["_py4cl_load_config"] = load_config
 try:
     # NumPy is used for Lisp -> Python conversion of multidimensional arrays
     eval_globals["_py4cl_numpy"] = numpy
-    eval_globals["_py4cl_load_pickled_ndarray_and_delete"] \
-      = load_pickled_ndarray_and_delete
+    eval_globals["_py4cl_load_pickled_ndarray"] \
+      = load_pickled_ndarray
 except:
     pass
 

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -89,8 +89,8 @@ Examples:
  (let ((a 10) (b 2))
    (py4cl:python-eval a "*" b)) => 20
 "
-   (delete-freed-python-objects)
-   (apply #'python-eval* #\e args))
+  (delete-freed-python-objects)
+  (apply #'python-eval* #\e args))
 
 (defun (setf python-eval) (value &rest args)
   "Set an expression to a value. Just adds \"=\" and the value

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -30,17 +30,17 @@ HANDLE slot is a unique key used to refer to a value in python."
 try:
   del _py4cl_objects[" handle "]
 except:
-  pass")))))
+  pass"))))
+  (delete-numpy-pickle-arrays))
 
 (defun delete-numpy-pickle-arrays ()
   "Delete pickled arrays, to free space."
-  (iter (while (> *numpy-pickle-index* 0))
-        (for filename =
-             (concatenate 'string
-                          (config-var 'numpy-pickle-location)
-                          "." (write-to-string *numpy-pickle-index*)))
-        (uiop:delete-file-if-exists filename)
-        (decf *numpy-pickle-index*)))
+  (loop :while (> *numpy-pickle-index* 0)
+        :for filename := (concatenate 'string
+                                      (config-var 'numpy-pickle-location)
+                                      ".to." (write-to-string *numpy-pickle-index*))
+        :do (decf *numpy-pickle-index*)
+            (uiop:delete-file-if-exists filename)))
 
 (defun make-python-object-finalize (&key (type "") handle)
     "Make a PYTHON-OBJECT struct with a finalizer.

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -36,11 +36,11 @@ except:
 (defun delete-numpy-pickle-arrays ()
   "Delete pickled arrays, to free space."
   (loop :while (> *numpy-pickle-index* 0)
-        :for filename := (concatenate 'string
-                                      (config-var 'numpy-pickle-location)
-                                      ".to." (write-to-string *numpy-pickle-index*))
         :do (decf *numpy-pickle-index*)
-            (uiop:delete-file-if-exists filename)))
+            (uiop:delete-file-if-exists
+             (concatenate 'string
+                          (config-var 'numpy-pickle-location)
+                          ".to." (write-to-string *numpy-pickle-index*)))))
 
 (defun make-python-object-finalize (&key (type "") handle)
     "Make a PYTHON-OBJECT struct with a finalizer.

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -70,17 +70,20 @@ which is interpreted correctly by python (3.7.2)."
 ;; this is incremented by pythonize and reset to 0 at the beginning of
 ;; every pyeval*/pycall from delete-numpy-pickle-arrays in reader.lisp
 (defmethod pythonize ((obj array))
+
+  ;; Transfer large arrays via pickling
   (when (and (config-var 'numpy-pickle-lower-bound)
              (config-var 'numpy-pickle-location)
              (> (array-total-size obj)
                 (config-var 'numpy-pickle-lower-bound)))
     (let ((filename (concatenate 'string
-				 (config-var 'numpy-pickle-location)
-				 "." (write-to-string (incf *numpy-pickle-index*)))))
+                                 (config-var 'numpy-pickle-location)
+                                 ".to." (write-to-string *numpy-pickle-index*))))
+      (incf *numpy-pickle-index*)
       (numpy-file-format:store-array obj filename)
       (return-from pythonize
-	(concatenate 'string "_py4cl_load_pickled_ndarray_and_delete('"
-		     filename"')"))))
+        (concatenate 'string "_py4cl_load_pickled_ndarray('"
+                     filename"')"))))
   
   ;; Handle case of empty array
   (if (= (array-total-size obj) 0)

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -629,7 +629,7 @@ class testclass:
 (deftest transfer-multiple-arrays (pytests)
   (when (and (py4cl:config-var 'py4cl:numpy-pickle-location)
              (py4cl:config-var 'py4cl:numpy-pickle-lower-bound))
-    (let ((dimensions `((,(py4cl:config-var 'py4cl:numpy-pickle-lower-bound))
+    (let ((dimensions `((,(* 2 (py4cl:config-var 'py4cl:numpy-pickle-lower-bound)))
                         (,(* 5 (py4cl:config-var 'py4cl:numpy-pickle-lower-bound))))))
       (assert-equalp dimensions
                      (mapcar #'array-dimensions 


### PR DESCRIPTION
- multiple arrays were not being transferred correctly
- use two name patterns for pickle files: to and from; should
  possibly be of help while doing nested callbacks
- py4cl.py was missing multiple array transfer support: added

There's another smallish change possible here - "lower-bound" seems to indicate ">=", while the semantics below are ">". Since no one has yet spotted the bug this PR intends to fix, I presume no one is using this feature; so, this change should be a non-breaker; I'll commit that change once I get an approval from you.