### PR TITLE
Add python-setattr generic method

### DIFF
--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -26,7 +26,7 @@
          ;; Delete object. This is called when an UnknownLispObject is deleted
          (#\d (free-handle (stream-read-value read-stream)))
 
-         ;; Slot access
+         ;; Slot read
          (#\s (destructuring-bind (handle slot-name) (stream-read-value read-stream)
                 (let ((object (lisp-object handle)))
                   ;; User must register a function to handle slot access
@@ -42,7 +42,14 @@
                                                      (format t "Enter a value to return: ")
                                                      (list (read)))
                                       return-value))))))
-         
+
+         ;; Slot write
+         (#\S (destructuring-bind (handle slot-name slot-value) (stream-read-value read-stream)
+                (let ((object (lisp-object handle)))
+                  ;; User must register a function to handle slot write
+                  (python-setattr object slot-name slot-value)
+                  (dispatch-reply write-stream nil))))
+
          ;; Callback. Value returned is a list, containing the function ID then the args
          (#\c
           (let ((call-value (stream-read-value read-stream)))

--- a/src/lisp-classes.lisp
+++ b/src/lisp-classes.lisp
@@ -3,3 +3,5 @@
 (defgeneric python-getattr (object slot-name)
   (:documentation "Called when python accesses an object's slot (__getattr__)"))
 
+(defgeneric python-setattr (object slot-name value)
+  (:documentation "Called when python sets an object's slot (__setattr__)"))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -27,7 +27,8 @@
    #:import-module
    #:export-function)
   (:export ; lisp-classes
-   #:python-getattr)
+   #:python-getattr
+   #:python-setattr)
   (:export ; config 
    #:*config*
    #:initialize

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -612,6 +612,30 @@ class testclass:
     (assert-equalp 3
         (py4cl:chain object other))))
 
+;; Define a method to handle slot writing from python
+(defmethod py4cl:python-setattr ((object test-class) slot-name set-to-value)
+  (cond
+    ((string= slot-name "value")
+     (setf (slot-value object 'value) set-to-value))
+    ((string= slot-name "thing")
+     (setf (slot-value object 'thing) set-to-value))
+    (t (call-next-method))))
+
+(deftest lisp-class-set-slots (pytests)
+  (let ((object (make-instance 'test-class :thing 23 :value 42)))
+    
+    ;; Set value
+    (py4cl:python-exec object ".thing = 3")
+
+    (assert-equalp 3 (slot-value object 'thing))
+    (assert-equalp 3 (py4cl:python-eval object ".thing"))
+
+    ;; Set again
+    (setf (py4cl:chain object thing) 72)
+    
+    (assert-equalp 72 (slot-value object 'thing))
+    (assert-equalp 72 (py4cl:chain object thing))))
+
 (deftest callback-in-remote-objects (pytests)
   ;; Callbacks send values to lisp in remote-objects environments
   (assert-equalp 6


### PR DESCRIPTION
Allows python code to set attributes/slots of Lisp objects.
User needs to register a python-setattr method for the class/struct passed to python.
Doesn't yet have any documentation, but includes tests.