### PR TITLE
add support to read/write special characters(utf-8) in LispWorks.

### DIFF
--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -95,8 +95,7 @@ Returns the string or nil on error
     #-lispworks
     (with-output-to-string (str)
       (loop for i from 1 to nchars do
-           (write-char (read-char stream) str)))
-    ))
+           (write-char (read-char stream) str)))))
 
 (defun stream-read-value (stream)
   "Get a value from a stream

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -172,21 +172,10 @@ The lisp function is stored in the same object store as other objects."
                ")"))
 
 (defun encode-lisp-string (string)
+  "Encode lisp string if necessary in some platform"
   #-lispworks string
   #+lispworks
   (translate-string-via-fli string :utf-8 :latin-1))
-
-(defun decode-external-string (string)
-  #-lispworks string
-  #+lispworks
-  (translate-string-via-fli string :latin-1 :utf-8))
-
-#+lispworks
-(defun translate-string-via-fli (string from to)
-  (fli:with-foreign-string (ptr elements bytes :external-format from)
-                           string
-    (declare (ignore elements bytes))
-    (fli:convert-from-foreign-string ptr :external-format to)))
 
 (defun stream-write-string (str stream)
   "Write a string to a stream, putting the length first"

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -171,12 +171,29 @@ The lisp function is stored in the same object store as other objects."
                (pythonize (denominator obj))
                ")"))
 
+(defun encode-lisp-string (string)
+  #-lispworks string
+  #+lispworks
+  (translate-string-via-fli string :utf-8 :latin-1))
+
+(defun decode-external-string (string)
+  #-lispworks string
+  #+lispworks
+  (translate-string-via-fli string :latin-1 :utf-8))
+
+#+lispworks
+(defun translate-string-via-fli (string from to)
+  (fli:with-foreign-string (ptr elements bytes :external-format from)
+                           string
+    (declare (ignore elements bytes))
+    (fli:convert-from-foreign-string ptr :external-format to)))
+
 (defun stream-write-string (str stream)
   "Write a string to a stream, putting the length first"
   ;; Convert the value to a string
   (princ (length str) stream)  ; Header, so length of string is known to reader
   (terpri stream)
-  (write-string str stream))
+  (write-string (encode-lisp-string str) stream))
     
 (defun stream-write-value (value stream)
   "Write a value to a stream, in a format which can be read


### PR DESCRIPTION
In LispWorks, it can't read/write utf-8 string well like this:

```lisp
(py4cl:python-eval "'’'")
```
This patch is to fix it.