### PR TITLE
Add keywords to allow sharing of streams in CCL

### DIFF
--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -22,15 +22,16 @@ COMMAND is a string with the python executable to launch e.g. \"python\"
 By default this is is set to *PYTHON-COMMAND*
 "
   (setf *python*
-        (uiop:launch-program
-         (concatenate 'string
-                      "exec "
-                      command  ; Run python executable
-                      " "
-                      ;; Path *base-pathname* is defined in py4cl.asd
-                      ;; Calculate full path to python script
-                      (namestring (merge-pathnames #p"py4cl.py" py4cl/config:*base-directory*)))
-         :input :stream :output :stream))
+        (apply #'uiop:launch-program
+               (concatenate 'string
+                            "exec "
+                            command  ; Run python executable
+                            " "
+                            ;; Path *base-pathname* is defined in py4cl.asd
+                            ;; Calculate full path to python script
+                            (namestring (merge-pathnames #p"py4cl.py" py4cl/config:*base-directory*)))
+               :input :stream :output :stream
+               #+ccl '(:sharing :lock) #-ccl nil))
   (incf *current-python-process-id*))
 
 (defun python-alive-p (&optional (process *python*))


### PR DESCRIPTION
Adding :sharing :lock allows multiple threads to access the
process streams.

Previously, the following error was given when attempting to
write to stdin in `python-exec*`:

```
Error of type SIMPLE-ERROR: Stream
<BASIC-CHARACTER-OUTPUT-STREAM UTF-8 (PIPE/5) #x30200A31EBFD>
is private to
<PROCESS Timed Process #:|process444318|(5) [Reset] #x30200A2E7FBD>
```